### PR TITLE
simplify deploy workflow to bun-only single job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
-name: Deploy Astro to GitHub Pages
+name: Deployment to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: ["master"]
   workflow_dispatch:
 
 permissions:
@@ -15,24 +15,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build with Astro
-        uses: withastro/action@v3
-        with:
-          node-version: 22
-
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Build with Astro
+        run: bun run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./dist"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Removes Node.js setup, uses single-job structure with configure-pages and setup-bun only.